### PR TITLE
fix: check item 보여지는 개수 1개로 수정

### DIFF
--- a/src/components/molecules/multiDropDown/MultiDropDown.tsx
+++ b/src/components/molecules/multiDropDown/MultiDropDown.tsx
@@ -58,7 +58,7 @@ const MultiDropDown: React.FC<Props> = ({
   defaultValue = [],
   onChange,
   placeholder = '선택',
-  maxSummary = 2,
+  maxSummary = 1,
   className,
   variant = 'outline',
 }) => {


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이슈 번호를 입력하세요 -->

Closes #38 

## ✨ 변경사항

 멀티 드랍다운에서 아이템 선택 시 라벨 개수 2->1개로 수정

## 🎯 리뷰 포인트

<!-- 리뷰어가 집중해서 봐야 할 부분을 명시하세요 -->

## 📝 추가 정보

<!-- 스크린샷, 테스트 방법 등 추가 정보가 있다면 작성하세요 -->

<img width="253" height="96" alt="스크린샷 2025-08-18 오전 12 27 07" src="https://github.com/user-attachments/assets/27fbc07a-e6d7-494a-98b8-bca4ab0d6cfe" />
